### PR TITLE
Add pagination

### DIFF
--- a/jobs/addOrUpdateMemberTags.js
+++ b/jobs/addOrUpdateMemberTags.js
@@ -1,7 +1,6 @@
 // Add or Update members to Mailchimp
 each(
   'members[*]',
-  //  post('/lists/a4e7ea0abc', state => ({
   post(
     '/lists/a1262d3eab',
     state => ({

--- a/jobs/getCampaignMembers.js
+++ b/jobs/getCampaignMembers.js
@@ -27,6 +27,7 @@ fn(state => {
   const totalSize = state.references[0]['totalSize'];
   if (totalSize > 2000) {
     for (let offset = 2000; offset < totalSize; offset += 2000) {
+      console.log('Querying data from', offset);
       state = query(`
       SELECT Id, Name, FirstName, LastName, Email, CreatedDate,
            Contact.AccountId, Contact.LastModifiedDate, Contact.CreatedDate,

--- a/jobs/getCampaignMembers.js
+++ b/jobs/getCampaignMembers.js
@@ -10,24 +10,45 @@ fn(state => {
   return { ...state, lastSyncTime, lastRunTime };
 });
 
-// Get campaign members from Salesforce
 query(
   state => `
 SELECT Id, Name, FirstName, LastName, Email, CreatedDate,
-       Contact.AccountId, Contact.LastModifiedDate, Contact.CreatedDate,
-       Campaign.Name, Campaign.Nome_da_Tag__c
+     Contact.AccountId, Contact.LastModifiedDate, Contact.CreatedDate,
+     Campaign.Name, Campaign.Nome_da_Tag__c
 FROM CampaignMember
 WHERE Campaign.RecordType.Name = 'Grupos, RTs ou Áreas Temáticas'
-      AND Campaign.IsActive = true
-      AND (Contact.LastModifiedDate > ${state.lastSyncTime} OR CreatedDate > ${state.lastSyncTime})
+    AND Campaign.IsActive = true
+    AND (Contact.LastModifiedDate > ${state.lastSyncTime} OR CreatedDate > ${state.lastSyncTime})
 `
 );
 
+// Retrieving the Remaining SOQL Query Results If we have more than 2000 records
+fn(state => {
+  const totalSize = state.references[0]['totalSize'];
+  if (totalSize > 2000) {
+    for (let offset = 2000; offset < totalSize; offset += 2000) {
+      state = query(`
+      SELECT Id, Name, FirstName, LastName, Email, CreatedDate,
+           Contact.AccountId, Contact.LastModifiedDate, Contact.CreatedDate,
+           Campaign.Name, Campaign.Nome_da_Tag__c
+      FROM CampaignMember
+      WHERE Campaign.RecordType.Name = 'Grupos, RTs ou Áreas Temáticas'
+          AND Campaign.IsActive = true
+          AND (Contact.LastModifiedDate > ${state.lastSyncTime} OR CreatedDate > ${state.lastSyncTime}) OFFSET ${offset}
+      `)(state);
+    }
+  }
+
+  return state;
+});
+
 // Seperate members for each batch
 fn(state => {
-  const campaignMembers = state.references[0]['records'];
+  const campaignMembers = state.references.map(ref => ref.records).flat();
   const membersToCreate = [];
   const membersToUpdate = [];
+
+  console.log(campaignMembers.length, 'campaignMembers');
 
   for (const member of campaignMembers) {
     const mappedMember = {
@@ -41,12 +62,14 @@ fn(state => {
       tags: [member.Campaign.Nome_da_tag__c],
     };
     if (member.CreatedDate > state.lastSyncTime) {
-      //if (member.Contact.LastModifiedDate > state.lastSyncTime) {
       membersToCreate.push({ ...mappedMember, status: 'subscribed' });
     } else {
       membersToUpdate.push(mappedMember);
     }
   }
+
+  console.log(membersToCreate.length, 'membersToCreate before merge tags');
+  console.log(membersToUpdate.length, 'membersToUpdate before merge tags');
 
   let mergeCreateMemberTags = [];
   let mergeUpdateMemberTags = [];
@@ -81,6 +104,16 @@ fn(state => {
       return result;
     }, []);
   }
+
+  console.log(
+    mergeCreateMemberTags.length,
+    'mergeCreateMemberTags after merge tags'
+  );
+
+  console.log(
+    mergeUpdateMemberTags.length,
+    'mergeUpdateMemberTags after merge tags'
+  );
 
   return {
     ...state,

--- a/jobs/getDeletedCampaignMembers.js
+++ b/jobs/getDeletedCampaignMembers.js
@@ -19,7 +19,10 @@ WHERE Id in (SELECT Contact__c FROM Deleted_Campaign_Member__c WHERE CreatedDate
 
 //Map Salesforce deleted campaign members to prepare for post to mailchimp
 fn(state => {
-  const deletedCampaignMembers = state.references[0]['records'];
+  const deletedCampaignMembers = state.references
+    .map(ref => ref.records)
+    .flat();
+
   const mappedMembers = [];
 
   for (const member of deletedCampaignMembers) {

--- a/jobs/getDeletedCampaignMembers.js
+++ b/jobs/getDeletedCampaignMembers.js
@@ -17,6 +17,24 @@ WHERE Id in (SELECT Contact__c FROM Deleted_Campaign_Member__c WHERE CreatedDate
 `
 );
 
+// Retrieving the Remaining SOQL Query Results If we have more than 2000 records
+fn(state => {
+  const totalSize = state.references[0]['totalSize'];
+  if (totalSize > 2000) {
+    for (let offset = 2000; offset < totalSize; offset += 2000) {
+      console.log('Querying data from', offset);
+      state = query(`
+      SELECT Name, Email, (SELECT Campaign_Tag_Name__c FROM CampaignMembers
+        WHERE Campaign.RecordType.Name = 'Grupos, RTs ou Áreas Temáticas' and  Campaign.IsActive = true)
+      FROM Contact
+      WHERE Id in (SELECT Contact__c FROM Deleted_Campaign_Member__c WHERE CreatedDate > ${state.lastSyncTime}) OFFSET ${offset}
+      `)(state);
+    }
+  }
+
+  return state;
+});
+
 //Map Salesforce deleted campaign members to prepare for post to mailchimp
 fn(state => {
   const deletedCampaignMembers = state.references

--- a/jobs/getDeletedCampaignMembers.js
+++ b/jobs/getDeletedCampaignMembers.js
@@ -23,9 +23,8 @@ fn(state => {
   const mappedMembers = [];
 
   for (const member of deletedCampaignMembers) {
-    
     const { CampaignMembers, Email } = member;
-    
+
     if (CampaignMembers) {
       mappedMembers.push({
         email_address: Email,

--- a/jobs/removeDeletedMemberTags.js
+++ b/jobs/removeDeletedMemberTags.js
@@ -2,17 +2,19 @@
 each(
   'members[*]',
   //post('/lists/a4e7ea0abc', state => ({
-    post('/lists/a1262d3eab', state => ({
-    sync_tags: true,
-    update_existing: true,
-    email_type: 'html',
-    members: state.data,
-  }),
-  {},
-  state => {
-    state.chunkErrors.push(state.response.errors);
-    return state;
-  }
+  post(
+    '/lists/a1262d3eab',
+    state => ({
+      sync_tags: true,
+      update_existing: true,
+      email_type: 'html',
+      members: state.data,
+    }),
+    {},
+    state => {
+      state.chunkErrors.push(state.response.errors);
+      return state;
+    }
   )
 );
 

--- a/jobs/removeDeletedMemberTags.js
+++ b/jobs/removeDeletedMemberTags.js
@@ -1,7 +1,6 @@
 //Sync contacts and create only active campaign tags
 each(
   'members[*]',
-  //post('/lists/a4e7ea0abc', state => ({
   post(
     '/lists/a1262d3eab',
     state => ({

--- a/workflow-2.json
+++ b/workflow-2.json
@@ -7,7 +7,7 @@
             "configuration": "tmp/salesforce-creds.json",
             "expression": "jobs/getDeletedCampaignMembers.js",
             "next": {
-                "removeDeletedMemberTags": "state.errors"
+                "removeDeletedMemberTags": "!state.errors"
             }
         },
         {


### PR DESCRIPTION
### Summary

**The Problem** 
It was learned that Salesforce SOQL Query has a limitation of 2,000 records per request. In scenarios where a query is returning more than 2000 records from the database, the full dataset will not be processed.

**Discovery** 
 It is possible to use the Salesforce [bulk query function](https://jsforce.github.io/document/#bulk-query) however, this function is not yet available in the OpenFn Salesforce adaptor so the pagination approach needed to be taken. An alternative approach that can be taken to [paginate in SOQL](https://stackoverflow.com/questions/1507377/soql-pagination-for-salesforce-api-queries), is to append OFFSET to the query.

**The Solution**
To paginate our SOQL query, we first run the full query to the database which returns all records which will need to be upserted. If the query returns more than 2000 records to the `state.references[0]['totalSize']`, then we will execute logic which goes through the entire returned query, offsetting in increments of 2000. In order to make the OFFSET dynamic and update with iteration, it has been set to increment by 2000 each time it runs through the for loop. To make all records available from each iteration, the array has been flattened. 