### PR TITLE
update conditional statement

### DIFF
--- a/jobs/getCampaignMembers.js
+++ b/jobs/getCampaignMembers.js
@@ -41,11 +41,11 @@ fn(state => {
       },
       tags: [member["Campaign.Nome_da_tag__c"]],
     };
-    if (member.CreatedDate > state.lastSyncTime) {
+    if ((member.LastModifiedDate > state.lastSyncTime) || (member.CreatedDate > state.lastSyncTime)) {
       membersToCreate.push({ ...mappedMember, status: 'subscribed' });
     } else {
       membersToUpdate.push(mappedMember);
-    }
+ }
   }
 
   console.log(membersToCreate.length, 'membersToCreate before merge tags');


### PR DESCRIPTION
### Short Summary
When email primary keys are updated, create a new contact 

### Implementation Notes
Using the same query criteria `(Contact.LastModifiedDate > ${state.lastSyncTime} OR CreatedDate > ${state.lastSyncTime})` to filter which member should be created and which should be updated. 

The job will now create a new contact in Mailchimp if the email has been changed. 
 
@bryceVeraSolutions have confirmed the contact with the updated email was created as a new contact and the contact with the old email also exists in the system as a separate contact with the old email id in Mailchimp

cc @williandeavila 